### PR TITLE
if the file exists, skip it.

### DIFF
--- a/download.py
+++ b/download.py
@@ -5,7 +5,7 @@ from __future__ import print_function, division
 import argparse
 import json
 from os.path import join
-
+import os.path
 import subprocess
 import urllib2
 
@@ -28,6 +28,9 @@ def download(out_dir, category, set_name, tag):
     else:
         out_name = '{category}_{set_name}_lmdb.zip'.format(**locals())
     out_path = join(out_dir, out_name)
+    if(os.path.isfile(out_path)):
+        print(out_path+" already downloaded and skip it.")
+        return
     cmd = ['curl', url, '-o', out_path]
     print('Downloading', category, set_name, 'set')
     subprocess.call(cmd)


### PR DESCRIPTION
I found that I may pause the downloading and resume later. Such little feature could save me a lot of time to re-download files.