### PR TITLE
Fix export errors caused by lmdb keys being binaries

### DIFF
--- a/data.py
+++ b/data.py
@@ -39,13 +39,13 @@ def export_images(db_path, out_dir, flat=False, limit=-1):
         cursor = txn.cursor()
         for key, val in cursor:
             if not flat:
-                image_out_dir = join(out_dir, '/'.join(key[:6]))
+                image_out_dir = join(out_dir, '/'.join(key.decode('ascii')[:6]))
             else:
                 image_out_dir = out_dir
             if not exists(image_out_dir):
                 os.makedirs(image_out_dir)
-            image_out_path = join(image_out_dir, key + '.webp')
-            with open(image_out_path, 'w') as fp:
+            image_out_path = join(image_out_dir, key.decode('ascii') + '.webp')
+            with open(image_out_path, 'wb') as fp:
                 fp.write(val)
             count += 1
             if count == limit:


### PR DESCRIPTION
Currently in python3, lmdb gives the keys as a binary, not string which causes the export to error with:

```
File "data.py", line 47, in export_images
    image_out_path = join(image_out_dir, key + '.webp')
TypeError: can't concat str to bytes
```

You can see a Colab without and with the fix here - https://colab.research.google.com/drive/1TUULlY7FkPQXdwN7iFddjAmqwFvaz-h3